### PR TITLE
fix mysql user password setting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       MYSQL_DATABASE: "webtrees"
       MYSQL_USER: "webtrees"
       MYSQL_ROOT_PASSWORD: "badpassword"
-      MYSQL_USER_PASSWORD: "badpassword"
+      MYSQL_PASSWORD: "badpassword"
     image: mariadb:latest
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
there is no such env variable called MYSQL_USER_PASSWORD for the mysql docker image. To set user password the MYSQL_PASSWORD variable should be set