### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=8.1
+ARG PHP_VERSION=8.3
 
 FROM docker.io/library/php:$PHP_VERSION-apache
 


### PR DESCRIPTION
Building with php 8.1 works (amd64) but running throws error that imagick version needs php 8.3

Just builded it wiht 8.3 and it seams to work.

Also the webtrees download page https://webtrees.net/download tells php version  8.3–8.5