### PR TITLE
Update link to docker-compose.yml in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ run standalone.
 ### Quickstart
 
 If you want to jump right in, take a look at the provided
-[docker-compose.yml](docker-compose.yml).
+[docker-compose.yml]([docker-compose.yml](https://github.com/NathanVaughn/webtrees-docker/blob/main/docker-compose.yml)).
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ run standalone.
 ### Quickstart
 
 If you want to jump right in, take a look at the provided
-[docker-compose.yml](https://github.com/NathanVaughn/webtrees-docker/blob/master/docker-compose.yml).
+[docker-compose.yml](docker-compose.yml).
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ run standalone.
 ### Quickstart
 
 If you want to jump right in, take a look at the provided
-[docker-compose.yml]([docker-compose.yml](https://github.com/NathanVaughn/webtrees-docker/blob/main/docker-compose.yml)).
+[docker-compose.yml](https://github.com/NathanVaughn/webtrees-docker/blob/main/docker-compose.yml).
 
 ### Environment Variables
 


### PR DESCRIPTION
Replace docker-compose link that was broken because of hardcoded branch name with a relative link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Quickstart README link to reference the main branch so the docker-compose example resolves to the intended revision. This ensures the referenced file renders and links consistently across GitHub, local views, and packaged contexts, improving discoverability and reducing confusion for users following setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->